### PR TITLE
qaqc.trim_vel: if all bins are underwater, do not slice bindist

### DIFF
--- a/stglib/aqd/qaqc.py
+++ b/stglib/aqd/qaqc.py
@@ -366,9 +366,10 @@ def trim_vel(ds, waves=False, data_vars=["U", "V", "W", "AGC"]):
         # there might be a better way to do this using xarray and named
         # dimensions, but this works for now
         lastbin = np.argmin(np.all(np.isnan(ds[data_vars[0]].values), axis=0) == False)
-
+        
+        if not lastbin == 0:
         # this trims so there are no all-nan rows in the data
-        ds = ds.isel(bindist=slice(0, lastbin))
+            ds = ds.isel(bindist=slice(0, lastbin))
 
         # TODO: need to add histcomment
 


### PR DESCRIPTION
I have AQD datasets with 34 bins. All bins are underwater at some point during data collection. 
So, after trimming via 'water level sl', there are no bins that have only NaNs. 

After velocity trimming, qaqc.trim_vel looks for the last full bin with values, and cuts out bins with only NaNs:
`lastbin = np.argmin(np.all(np.isnan(ds[data_vars[0]].values), axis=0) == False)`
`ds = ds.isel(bindist=slice(0, lastbin))`

Because the AQD data I am working with have no bins above water at all times, it cannot find the last full bin and sets lastbin to 0. 
This causes the function to delete all of the bins and runaqdcdf2nc.py raises an error. 

I added: `if not lastbin == 0:` and it now works. 

There could be another solution to this problem? 
If you would like me to send files please let me know.

Thanks for all the help, 
Bo 