### PR TITLE
updates to exo.py

### DIFF
--- a/stglib/exo.py
+++ b/stglib/exo.py
@@ -355,27 +355,27 @@ def ds_add_attrs(ds):
     if "fDOMRFU" in ds:
         ds["fDOMRFU"].attrs.update(
             {
-                "units": "1",
-                "units_note": "Relative fluorescence units",
-                "long_name": "Fluorescent dissolved organic matter",
+                "units": "percent",
+                "long_name": "Fluorescent dissolved organic matter, RFU",
+                "comments": "Relative fluorescent units (RFU)",
             }
         )
 
     if "fDOMQSU" in ds:
         ds["fDOMQSU"].attrs.update(
             {
-                "units": "1",
-                "units_note": "Quinine sulfate equivalent units",
-                "long_name": "Fluorescent dissolved organic matter",
+                "units": "1e-9",
+                "long_name": "Fluorescent dissolved organic matter, QSU",
+                "comments": "Quinine sulfate units (QSU)",
             }
         )
 
     if "CHLrfu" in ds:
         ds["CHLrfu"].attrs.update(
             {
-                "units": "1",
-                "units_note": "Relative fluorescence units",
-                "long_name": "Chlorophyll A",
+                "units": "percent",
+                "long_name": "Chlorophyll A, RFU",
+                "comments": "Relative fluorescence units (RFU)",
             }
         )
 
@@ -387,9 +387,9 @@ def ds_add_attrs(ds):
     if "BGAPErfu" in ds:
         ds["BGAPErfu"].attrs.update(
             {
-                "units": "1",
-                "units_note": "Relative fluorescence units",
-                "long_name": "Blue green algae phycoerythrin",
+                "units": "percent",
+                "long_name": "Blue green algae phycoerythrin, RFU",
+                "comments": "Relative fluorescence units (RFU)",
             }
         )
 
@@ -428,8 +428,9 @@ def ds_add_attrs(ds):
 
     ds["S_41"].attrs.update(
         {
-            "units": "Practical salinity units (PSU)",
-            "long_name": "Salinity",
+            "units": "1e-3",
+            "long_name": "Salinity, PSU",
+            "comments": "Practical salinity units (PSU)",
             "epic_code": 41,
             "standard_name": "sea_water_salinity",
         }
@@ -457,8 +458,9 @@ def ds_add_attrs(ds):
     if "Turb" in ds:
         ds["Turb"].attrs.update(
             {
-                "units": "Nephelometric turbidity units (NTU)",
-                "long_name": "Turbidity",
+                "units": "1",
+                "long_name": "Turbidity, NTU",
+                "comments": "Nephelometric turbidity units (NTU)",
                 "standard_name": "sea_water_turbidity",
             }
         )
@@ -466,8 +468,9 @@ def ds_add_attrs(ds):
     if "Turb_FNU" in ds:
         ds["Turb_FNU"].attrs.update(
             {
-                "units": "Formazin nephelometric units (FNU)",
-                "long_name": "Turbidity",
+                "units": "1",
+                "long_name": "Turbidity, FNU",
+                "comments": "Formazin nephelometric units (FNU)",
                 "standard_name": "sea_water_turbidity",
             }
         )

--- a/stglib/exo.py
+++ b/stglib/exo.py
@@ -215,6 +215,7 @@ def cdf_to_nc(cdf_filename, atmpres=False):
         # nLF_Cond_µS_per_cm: "This convention is typically used in German markets." pp. 85
         "nLF_Cond_µS_per_cm",
         "Vertical_Position_m",
+        "pH_mV",
     ]:
         if k in ds:
             ds = ds.drop(k)
@@ -246,12 +247,12 @@ def cdf_to_nc(cdf_filename, atmpres=False):
     # add lat/lon coordinates
     ds = utils.ds_add_lat_lon(ds)
 
-    ds = ds_add_attrs(ds)
-
     # ds = utils.create_water_depth(ds)
     ds = utils.create_nominal_instrument_depth(ds)
 
     ds = utils.create_z(ds)
+
+    ds = ds_add_attrs(ds)
 
     # add lat/lon coordinates to each variable
     # for var in ds.variables:
@@ -318,7 +319,6 @@ def ds_rename_vars(ds):
         "Turbidity_NTU": "Turb",
         "Turbidity_FNU": "Turb_FNU",
         "pH": "pH_159",
-        "pH_mV": "pHmV",
     }
 
     # check to make sure they exist before trying to rename
@@ -355,7 +355,8 @@ def ds_add_attrs(ds):
     if "fDOMRFU" in ds:
         ds["fDOMRFU"].attrs.update(
             {
-                "units": "Relative fluorescence units (RFU)",
+                "units": "1",
+                "units_note": "Relative fluorescence units",
                 "long_name": "Fluorescent dissolved organic matter",
             }
         )
@@ -363,14 +364,19 @@ def ds_add_attrs(ds):
     if "fDOMQSU" in ds:
         ds["fDOMQSU"].attrs.update(
             {
-                "units": "Quinine sulfate equivalent units (QSU)",
+                "units": "1",
+                "units_note": "Quinine sulfate equivalent units",
                 "long_name": "Fluorescent dissolved organic matter",
             }
         )
 
     if "CHLrfu" in ds:
         ds["CHLrfu"].attrs.update(
-            {"units": "Relative fluorescence units (RFU)", "long_name": "Chlorophyll A"}
+            {
+                "units": "1",
+                "units_note": "Relative fluorescence units",
+                "long_name": "Chlorophyll A",
+            }
         )
 
     if "Fch_906" in ds:
@@ -381,7 +387,8 @@ def ds_add_attrs(ds):
     if "BGAPErfu" in ds:
         ds["BGAPErfu"].attrs.update(
             {
-                "units": "Relative fluorescence units (RFU)",
+                "units": "1",
+                "units_note": "Relative fluorescence units",
                 "long_name": "Blue green algae phycoerythrin",
             }
         )
@@ -570,7 +577,6 @@ def exo_qaqc(ds):
         "OST_62",
         "DO",
         "pH_159",
-        "pHmV",
         "P_1ac",
         "P_1",
     ]

--- a/stglib/exo.py
+++ b/stglib/exo.py
@@ -357,7 +357,7 @@ def ds_add_attrs(ds):
             {
                 "units": "percent",
                 "long_name": "Fluorescent dissolved organic matter, RFU",
-                "comments": "Relative fluorescent units (RFU)",
+                "comments": "Relative fluorescence units (RFU)",
             }
         )
 


### PR DESCRIPTION
Fix non-UDUNIT units in exo.py by setting to "1" and add "units_note:" variable attribute in those instances to describe units. Fix issue with _FillValue attribute showing up in some coordinate variables. Checked formatting with black and ran test_scripts. 