### PR TITLE
add max_diff qaqc for profile data

### DIFF
--- a/stglib/aqd/cdf2nc.py
+++ b/stglib/aqd/cdf2nc.py
@@ -88,6 +88,7 @@ def cdf_to_nc(cdf_filename, atmpres=False):
         VEL = qaqc.trim_med_diff_pct(VEL, var)
         VEL = qaqc.trim_bad_ens(VEL, var)
         VEL = qaqc.trim_fliers(VEL, var)
+        VEL = qaqc.trim_maxabs_diff_z(VEL, var)
         VEL = aqdutils.trim_single_bins(VEL, var)
 
     # Add min/max values

--- a/stglib/core/qaqc.py
+++ b/stglib/core/qaqc.py
@@ -236,3 +236,24 @@ def trim_fliers(ds, var):
         ds = utils.insert_note(ds, var, notetxt)
 
     return ds
+
+
+def trim_maxabs_diff_z(ds, var):
+    if var + "_maxabs_diff_z" in ds.attrs:
+        print(
+            "%s: Trimming using maximum absolute diff of %5.2f on z dim"
+            % (var, ds.attrs[var + "_maxabs_diff_z"].round(2))
+        )
+
+        bads = np.abs(ds[var].diff(dim="z")) >= ds.attrs[var + "_maxabs_diff_z"]
+        ds[var][:, 1:] = ds[var].where(~bads)
+
+        notetxt = (
+            "Values filled where data increases by more than %5.2f "
+            "units (absolute) in a single time step along the z dimension. "
+            % ds.attrs[var + "_maxabs_diff_z"].round(2)
+        )
+
+        ds = utils.insert_note(ds, var, notetxt)
+
+    return ds


### PR DESCRIPTION
Add def in qaqc.py to handle maximum difference filtering along z dimension in profile data. Add new def to list of trimming options for Aquadopp data processing in aqd/cdf2nc.py.