### PR TITLE
Add EofE qaqc capabilities

### DIFF
--- a/stglib/core/qaqc.py
+++ b/stglib/core/qaqc.py
@@ -296,13 +296,14 @@ def trim_mask(ds, var):
 
     return ds
 
+
 def trim_maxabs_diff(ds, var):
     if var + "_maxabs_diff" in ds.attrs:
         val = ds.attrs[var + "_maxabs_diff"]
-        print(
-            f"{var}: Trimming using maximum absolute diff of {val}"
-        )
-        ds[var][np.abs(np.ediff1d(ds[var], to_begin=0)) > ds.attrs[var + "_maxabs_diff"]] = np.nan
+        print(f"{var}: Trimming using maximum absolute diff of {val}")
+        ds[var][
+            np.abs(np.ediff1d(ds[var], to_begin=0)) > ds.attrs[var + "_maxabs_diff"]
+        ] = np.nan
 
         notetxt = (
             f"Values filled where data increases or decreases by more than {val} "

--- a/stglib/core/qaqc.py
+++ b/stglib/core/qaqc.py
@@ -295,3 +295,20 @@ def trim_mask(ds, var):
                 )
 
     return ds
+
+def trim_maxabs_diff(ds, var):
+    if var + "_maxabs_diff" in ds.attrs:
+        val = ds.attrs[var + "_maxabs_diff"]
+        print(
+            f"{var}: Trimming using maximum absolute diff of {val}"
+        )
+        ds[var][np.abs(np.ediff1d(ds[var], to_begin=0)) > ds.attrs[var + "_maxabs_diff"]] = np.nan
+
+        notetxt = (
+            f"Values filled where data increases or decreases by more than {val} "
+            "units in a single time step. "
+        )
+
+        ds = utils.insert_note(ds, var, notetxt)
+
+    return ds

--- a/stglib/eofe.py
+++ b/stglib/eofe.py
@@ -85,7 +85,7 @@ def cdf_to_nc(cdf_filename):
     # Clip data to in/out water times or via good_ens
     ds = utils.clip_ds(ds)
 
-    # Trim data when instrumet is out of water during a deployment and extra bins if good_bins specified
+    # Trim data when instrument is out of water during a deployment and extra bins if good_bins specified
     if "bins" in ds:
         ds = trim_alt(ds)
     else:
@@ -96,7 +96,7 @@ def cdf_to_nc(cdf_filename):
         ds = calc_bin_height(ds)
 
     # calculate corrected altitude (distance to bed/b_range) with adjusted sound speed
-    ds = calc_cor_brange(ds)  # 12/23/21
+    ds = calc_cor_brange(ds)
 
     # calculate corrected bin height (on NAVD88 datum) with adjusted sound speed
     if "bins" in ds:
@@ -145,7 +145,7 @@ def cdf_to_nc(cdf_filename):
     )
     print("Done writing netCDF file", nc_filename)
 
-    # Average busrt and write to -a.nc file 12/23/21
+    # Average busrt and write to -a.nc file
     ds = average_burst(ds)
 
     for var in ds.data_vars:
@@ -163,7 +163,7 @@ def cdf_to_nc(cdf_filename):
         ds = aqdutils.trim_single_bins(ds, var)
         ds = qaqc.trim_fliers(ds, var)
 
-    # after check for masking vars by other vars
+    # after check for masking vars by others
     for var in ds.data_vars:
         ds = qaqc.trim_mask(ds, var)
 
@@ -175,7 +175,7 @@ def cdf_to_nc(cdf_filename):
     # ds['time']=ds['time'].astype('datetime64[s]')
     ds.to_netcdf(
         nc_filename, unlimited_dims=["time"], encoding={"time": {"dtype": "i4"}}
-    )  # 5/20/22- save time as int32
+    )
 
     utils.check_compliance(nc_filename, conventions=ds.attrs["Conventions"])
 
@@ -343,7 +343,7 @@ def ds_rename_vars(ds):
     varnames = {
         "Ping": "ping",
         "Ping_num_in_series": "ping_num_in_series",
-        "Temperature_C": "Tx_1211",  # 12/23/21
+        "Temperature_C": "Tx_1211",
         "Pitch_deg": "Ptch_1216",
         "Roll_deg": "Roll_1217",
         "Counts": "AGC_1202",
@@ -359,7 +359,7 @@ def ds_rename_vars(ds):
     return ds.rename(newvars)
 
 
-def ds_add_attrs(ds):  # 12/23/21
+def ds_add_attrs(ds):
     # modified from exo.ds_add_attrs
     ds = utils.ds_coord_no_fillvalue(ds)
 

--- a/stglib/tests/data/1123Aea_example_config.yaml
+++ b/stglib/tests/data/1123Aea_example_config.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8f5646da47ab20e4374acfc0c1c4f1d450ddff4a02723d079f66f63092a0f8f6
-size 678
+oid sha256:a040790195c7b0787af28c32a25bf0de068adda8dd7318e15a321eaee01c3408
+size 654

--- a/stglib/tests/data/glob_att1123A_msl.txt
+++ b/stglib/tests/data/glob_att1123A_msl.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f1dfe43133428defe6e1c8906aecc730b533a658063850d6d9598fb8510fb463
-size 973
+oid sha256:cc41ffbb0c515d0b834af92f974bf65db4f71dc3b904398208f637b5b4b7748a
+size 1147


### PR DESCRIPTION
Modify eofe.py to include trimming of data by new "trim_alt" def and existing code in qaqc.py and others. Add def to qaqc.py to trim 1d variable by maximum absolute difference method. New trim_alt def in eofe.py allows "altitude" method to trim data when out of water during a deployment, e.g. where instrument is exposed during low water events, or just low tides, and also allows clipping of extra bins as specified by user in config yaml file. Tests updated to include new capabilities.