### PR TITLE
Edits to QA/QC for ECO instruments

### DIFF
--- a/stglib/eco.py
+++ b/stglib/eco.py
@@ -278,11 +278,11 @@ def eco_qaqc(ds):
 
             ds = qaqc.trim_med_diff_pct(ds, var)
 
-            ds = qaqc.trim_max_std(ds, var)
-
             ds = qaqc.trim_maxabs_diff_2d(ds, var)
-        
+
             ds = qaqc.trim_maxabs_diff(ds, var)
+
+            ds = qaqc.trim_max_std(ds, var)
 
             ds = qaqc.trim_min(ds, var)
 

--- a/stglib/eco.py
+++ b/stglib/eco.py
@@ -270,12 +270,6 @@ def eco_qaqc(ds):
     # QA/QC ECO data
     if "ntu" in ds.attrs["INST_TYPE"].lower():
         for var in ["Turb"]:
-            ds = qaqc.trim_max_std(ds, var)
-
-            ds = qaqc.trim_min(ds, var)
-
-            ds = qaqc.trim_max(ds, var)
-
             ds = qaqc.trim_min_diff(ds, var)
 
             ds = qaqc.trim_max_diff(ds, var)
@@ -284,6 +278,20 @@ def eco_qaqc(ds):
 
             ds = qaqc.trim_med_diff_pct(ds, var)
 
+            ds = qaqc.trim_max_std(ds, var)
+
+            ds = qaqc.trim_maxabs_diff_2d(ds, var)
+        
+            ds = qaqc.trim_maxabs_diff(ds, var)
+
+            ds = qaqc.trim_min(ds, var)
+
+            ds = qaqc.trim_max(ds, var)
+
             ds = qaqc.trim_bad_ens(ds, var)
+
+        # after check for masking vars by others
+        for var in ["Turb"]:
+            ds = qaqc.trim_mask(ds, var)
 
     return ds

--- a/stglib/tests/data/11032Decn_config.yaml
+++ b/stglib/tests/data/11032Decn_config.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f31265b8037dc450e0a3e0d90c5b8575066b34da3dffd3514132bf83317cd77f
-size 667
+oid sha256:2b5cfa40aecb897f642a3947c9ffa0f69d1484123d9bc6426256dd43dfd21a43
+size 690


### PR DESCRIPTION
Add new qaqc function calls and edit order of calls so that difference filtering fcns are called first.