### PR TITLE
Fixclockdrift

### DIFF
--- a/stglib/core/utils.py
+++ b/stglib/core/utils.py
@@ -804,9 +804,10 @@ def shift_time(ds, timeshift):
                 np.linspace(0, -ds.attrs["ClockDrift"], len(ds["time"])), "s"
             )
 
+            ds["time"]=ds.time.dt.round("1s")
+            
             histtext = (
-                "{}: Time linearly interpolated by {} s using ClockDrift.\n".format(
-                    datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                "Time linearly interpolated by {} s using ClockDrift and rounded to the nearest second.\n".format(
                     -ds.attrs["ClockDrift"],
                 )
             )

--- a/stglib/core/utils.py
+++ b/stglib/core/utils.py
@@ -804,12 +804,10 @@ def shift_time(ds, timeshift):
                 np.linspace(0, -ds.attrs["ClockDrift"], len(ds["time"])), "s"
             )
 
-            ds["time"]=ds.time.dt.round("1s")
-            
-            histtext = (
-                "Time linearly interpolated by {} s using ClockDrift and rounded to the nearest second.\n".format(
-                    -ds.attrs["ClockDrift"],
-                )
+            ds["time"] = ds.time.dt.round("1s")
+
+            histtext = "Time linearly interpolated by {} s using ClockDrift and rounded to the nearest second.\n".format(
+                -ds.attrs["ClockDrift"],
             )
 
             insert_history(ds, histtext)

--- a/stglib/tests/data/1151Bexo_config.yaml
+++ b/stglib/tests/data/1151Bexo_config.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b80dbcf222d541f1c7d01e08c9c414adf233d89ec4efb8348c67b9abbaff3ed5
-size 1140
+oid sha256:debce684b109cc3fc1c5f7ff4387a554fb645c31bf73cfedabf6b6ae7fef4fc9
+size 1217


### PR DESCRIPTION
Round time units to 1 second in Clock_Drift part of utils.shift_time def. This necessary because time index is saved as dtype 'i4' in the CF netcdf files for data release (.nc files).