### PR TITLE
tidy up attributes

### DIFF
--- a/stglib/aqd/aqdutils.py
+++ b/stglib/aqd/aqdutils.py
@@ -666,11 +666,11 @@ def check_attrs(ds, waves=False, inst_type="AQD"):
         # the .SEN file, but this requires reading the first good burst, which
         # is unknown at this point.
 
-        ds.attrs["INST_TYPE"] = "Nortek Aquadopp Profiler"
+        ds.attrs["instrument_type"] = "Nortek Aquadopp Profiler"
     elif inst_type == "VEC":
         ds.attrs["serial_number"] = ds.attrs["VECSerialNumber"]
         ds.attrs["frequency"] = ds.attrs["VECFrequency"]
-        ds.attrs["INST_TYPE"] = "Nortek Vector"
+        ds.attrs["instrument_type"] = "Nortek Vector"
 
     return ds
 
@@ -697,8 +697,8 @@ def create_bindist(ds, waves=False):
 def update_attrs(ds, waves=False):
     """Define dimensions and variables in NetCDF file"""
 
-    ds["lat"] = xr.DataArray([ds.attrs["latitude"]], dims=("lat"), name="lat")
-    ds["lon"] = xr.DataArray([ds.attrs["longitude"]], dims=("lon"), name="lon")
+    ds["latitude"] = xr.DataArray([ds.attrs["latitude"]], dims=("lat"), name="lat")
+    ds["longitude"] = xr.DataArray([ds.attrs["longitude"]], dims=("lon"), name="lon")
 
     ds["TransMatrix"] = xr.DataArray(ds.attrs["AQDTransMatrix"])
     # Need to remove AQDTransMatrix from attrs for netCDF3 compliance
@@ -708,7 +708,7 @@ def update_attrs(ds, waves=False):
         {"standard_name": "time", "axis": "T", "long_name": "time (UTC)"}
     )
 
-    ds["lat"].attrs.update(
+    ds["latitude"].attrs.update(
         {
             "units": "degree_north",
             "long_name": "Latitude",
@@ -717,7 +717,7 @@ def update_attrs(ds, waves=False):
         }
     )
 
-    ds["lon"].attrs.update(
+    ds["longitude"].attrs.update(
         {
             "units": "degree_east",
             "long_name": "Longitude",
@@ -727,8 +727,8 @@ def update_attrs(ds, waves=False):
     )
 
     if "position_datum" in ds.attrs:
-        ds["lat"].attrs["datum"] = ds.attrs["position_datum"]
-        ds["lon"].attrs["datum"] = ds.attrs["position_datum"]
+        ds["latitude"].attrs["datum"] = ds.attrs["position_datum"]
+        ds["longitude"].attrs["datum"] = ds.attrs["position_datum"]
 
     ds["bindist"].attrs.update(
         {
@@ -805,7 +805,7 @@ def update_attrs(ds, waves=False):
         {
             "units": "degrees",
             "long_name": "Instrument Heading",
-            "datum": "magnetic north",
+            #"datum": "magnetic north",
         }
     )
 
@@ -861,14 +861,14 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
             {
                 "serial_number": sn,
                 "initial_instrument_height": dsattrs["initial_instrument_height"],
-                "nominal_instrument_depth": dsattrs["nominal_instrument_depth"],
+                #"nominal_instrument_depth": dsattrs["nominal_instrument_depth"],
                 "height_depth_units": "m",
-                "sensor_type": dsattrs["INST_TYPE"],
+                #"sensor_type": dsattrs["INST_TYPE"],
             }
         )
 
-    if utils.is_cf(ds):
-        ds.attrs["featureType"] = "timeSeriesProfile"
+    #if utils.is_cf(ds):
+    #    ds.attrs["featureType"] = "timeSeriesProfile"
 
     # Update attributes for EPIC and STG compliance
     ds = utils.ds_coord_no_fillvalue(ds)
@@ -900,7 +900,7 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
             {
                 "name": "u",
                 "long_name": "Eastward Velocity",
-                "generic_name": "u",
+                #"generic_name": "u",
                 "epic_code": 1205,
             }
         )
@@ -910,7 +910,7 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
             {
                 "name": "v",
                 "long_name": "Northward Velocity",
-                "generic_name": "v",
+                #"generic_name": "v",
                 "epic_code": 1206,
             }
         )
@@ -920,7 +920,7 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
             {
                 "name": "w",
                 "long_name": "Vertical Velocity",
-                "generic_name": "w",
+                #"generic_name": "w",
                 "epic_code": 1204,
             }
         )
@@ -932,7 +932,7 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
                 "name": "AGC",
                 "long_name": "Average Echo Intensity",
                 "generic_name": "AGC",
-                "epic_code": 1202,
+                #"epic_code": 1202,
             }
         )
 
@@ -956,7 +956,7 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
                 {
                     "units": "m s-1",
                     "long_name": "Beam 1 Velocity",
-                    "generic_name": "vel1",
+                    #"generic_name": "vel1",
                     "epic_code": 1277,
                 }
             )
@@ -965,7 +965,7 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
                 {
                     "units": "m s-1",
                     "long_name": "Beam 2 Velocity",
-                    "generic_name": "vel2",
+                    #"generic_name": "vel2",
                     "epic_code": 1278,
                 }
             )
@@ -974,7 +974,7 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
                 {
                     "units": "m s-1",
                     "long_name": "Beam 3 Velocity",
-                    "generic_name": "vel3",
+                    #"generic_name": "vel3",
                     "epic_code": 1279,
                 }
             )
@@ -984,7 +984,7 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
             {
                 "units": "counts",
                 "long_name": "Echo Intensity (AGC) Beam 1",
-                "generic_name": "AGC1",
+                #"generic_name": "AGC1",
                 "epic_code": 1221,
             }
         )
@@ -994,7 +994,7 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
             {
                 "units": "counts",
                 "long_name": "Echo Intensity (AGC) Beam 2",
-                "generic_name": "AGC2",
+                #"generic_name": "AGC2",
                 "epic_code": 1222,
             }
         )
@@ -1004,7 +1004,7 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
             {
                 "units": "counts",
                 "long_name": "Echo Intensity (AGC) Beam 3",
-                "generic_name": "AGC3",
+                #"generic_name": "AGC3",
                 "epic_code": 1223,
             }
         )
@@ -1014,7 +1014,7 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
             "units": "dbar",
             "name": "P",
             "long_name": "Uncorrected pressure",
-            "generic_name": "depth",
+            #"generic_name": "depth",
             "epic_code": 1,
         }
     )  # TODO: is this generic name correct?
@@ -1060,8 +1060,8 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
         {
             "units": "C",
             "name": "Tx",
-            "long_name": "Instrument Transducer Temperature",
-            "generic_name": "temp",
+            "long_name": "Instrument Internal Temperature",
+            #"generic_name": "temp",
             "epic_code": 1211,
         }
     )
@@ -1071,7 +1071,7 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
             "units": "degrees",
             "name": "Hdg",
             "long_name": "Instrument Heading",
-            "generic_name": "hdg",
+            #"generic_name": "hdg",
             "epic_code": 1215,
         }
     )
@@ -1094,7 +1094,7 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
             "units": "degrees",
             "name": "Ptch",
             "long_name": "Instrument Pitch",
-            "generic_name": "ptch",
+            #"generic_name": "ptch",
             "epic_code": 1216,
         }
     )
@@ -1104,7 +1104,7 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
             "units": "degrees",
             "name": "Roll",
             "long_name": "Instrument Roll",
-            "generic_name": "roll",
+            #"generic_name": "roll",
             "epic_code": 1217,
         }
     )

--- a/stglib/aqd/aqdutils.py
+++ b/stglib/aqd/aqdutils.py
@@ -202,7 +202,7 @@ def set_orientation(VEL, T):
     """
     Create z variable depending on instrument orientation
     """
-
+    """
     if "Pressure_ac" in VEL:
         presvar = "Pressure_ac"
     else:
@@ -232,9 +232,10 @@ def set_orientation(VEL, T):
         # if we don't have NAVD88 elevations, reference to sea-bed elevation
         elev = VEL.attrs["transducer_offset_from_bottom"]
         long_name = "height relative to sea bed"
-
+    """
     T_orig = T.copy()
 
+    """
     if VEL.attrs["orientation"] == "UP":
         print("User instructed that instrument was pointing UP")
 
@@ -242,12 +243,14 @@ def set_orientation(VEL, T):
         VEL["depth"] = xr.DataArray(
             np.nanmean(VEL[presvar]) - VEL["bindist"].values, dims="depth"
         )
-
+    
     elif VEL.attrs["orientation"] == "DOWN":
+    """
+    if VEL.attrs["orientation"] == "DOWN":
         print("User instructed that instrument was pointing DOWN")
         T[1, :] = -T[1, :]
         T[2, :] = -T[2, :]
-
+    """
         VEL["z"] = xr.DataArray(elev - VEL["bindist"].values, dims="z")
         VEL["depth"] = xr.DataArray(
             np.nanmean(VEL[presvar]) + VEL["bindist"].values, dims="depth"
@@ -265,7 +268,7 @@ def set_orientation(VEL, T):
     VEL["depth"].attrs["units"] = "m"
     VEL["depth"].attrs["positive"] = "down"
     VEL["depth"].attrs["long_name"] = "depth below mean sea level"
-
+    """
     return VEL, T, T_orig
 
 
@@ -697,8 +700,8 @@ def create_bindist(ds, waves=False):
 def update_attrs(ds, waves=False):
     """Define dimensions and variables in NetCDF file"""
 
-    ds["latitude"] = xr.DataArray([ds.attrs["latitude"]], dims=("lat"), name="lat")
-    ds["longitude"] = xr.DataArray([ds.attrs["longitude"]], dims=("lon"), name="lon")
+    ds["latitude"] = xr.DataArray([ds.attrs["latitude"]], dims=("latitude"))
+    ds["longitude"] = xr.DataArray([ds.attrs["longitude"]], dims=("longitude"))
 
     ds["TransMatrix"] = xr.DataArray(ds.attrs["AQDTransMatrix"])
     # Need to remove AQDTransMatrix from attrs for netCDF3 compliance
@@ -711,6 +714,7 @@ def update_attrs(ds, waves=False):
     ds["latitude"].attrs.update(
         {
             "units": "degree_north",
+            "axis": "Y",
             "long_name": "Latitude",
             "standard_name": "latitude",
             "epic_code": 500,
@@ -720,15 +724,16 @@ def update_attrs(ds, waves=False):
     ds["longitude"].attrs.update(
         {
             "units": "degree_east",
+            "axis": "X",
             "long_name": "Longitude",
             "standard_name": "longitude",
             "epic_code": 502,
         }
     )
 
-    if "position_datum" in ds.attrs:
-        ds["latitude"].attrs["datum"] = ds.attrs["position_datum"]
-        ds["longitude"].attrs["datum"] = ds.attrs["position_datum"]
+    # if "position_datum" in ds.attrs:
+    #    ds["latitude"].attrs["datum"] = ds.attrs["position_datum"]
+    #    ds["longitude"].attrs["datum"] = ds.attrs["position_datum"]
 
     ds["bindist"].attrs.update(
         {
@@ -737,19 +742,20 @@ def update_attrs(ds, waves=False):
             "bin_size": ds.attrs["bin_size"],
             "center_first_bin": ds.attrs["center_first_bin"],
             "bin_count": ds.attrs["bin_count"],
-            "transducer_offset_from_bottom": ds.attrs["transducer_offset_from_bottom"],
+            # "transducer_offset_from_bottom": ds.attrs["transducer_offset_from_bottom"],
         }
     )
 
     ds["Temperature"].attrs.update(
-        {"units": "C", "long_name": "Temperature", "generic_name": "temp"}
+        # {"units": "C", "long_name": "Temperature", "generic_name": "temp"}
+        {"units": "C", "long_name": "Temperature"}
     )
 
     ds["Pressure"].attrs.update(
         {
             "units": "dbar",
             "long_name": "Uncorrected pressure",
-            "generic_name": "press",
+            # "generic_name": "press",
             "note": (
                 "Raw pressure from instrument, not corrected for changes "
                 "in atmospheric pressure"
@@ -762,18 +768,18 @@ def update_attrs(ds, waves=False):
             ds["VEL" + str(n)].attrs.update(
                 {
                     "units": "m s-1",
-                    "transducer_offset_from_bottom": ds.attrs[
-                        "transducer_offset_from_bottom"
-                    ],
+                    # "transducer_offset_from_bottom": ds.attrs[
+                    #    "transducer_offset_from_bottom"
+                    # ],
                 }
             )
         ds["AMP" + str(n)].attrs.update(
             {
                 "long_name": "Beam " + str(n) + " Echo Amplitude",
                 "units": "counts",
-                "transducer_offset_from_bottom": ds.attrs[
-                    "transducer_offset_from_bottom"
-                ],
+                # "transducer_offset_from_bottom": ds.attrs[
+                #    "transducer_offset_from_bottom"
+                # ],
             }
         )
 
@@ -805,7 +811,7 @@ def update_attrs(ds, waves=False):
         {
             "units": "degrees",
             "long_name": "Instrument Heading",
-            #"datum": "magnetic north",
+            # "datum": "magnetic north",
         }
     )
 
@@ -822,7 +828,7 @@ def update_attrs(ds, waves=False):
 
     ds["TransMatrix"].attrs["long_name"] = "Transformation Matrix " "for this Aquadopp"
     if "burst" in ds:
-        ds["burst"].attrs.update({"units": "count", "long_name": "Record number"})
+        ds["burst"].attrs.update({"units": "count", "long_name": "Burst number"})
 
     return ds
 
@@ -859,15 +865,15 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
             sn = dsattrs["VECSerialNumber"]
         var.attrs.update(
             {
-                "serial_number": sn,
-                "initial_instrument_height": dsattrs["initial_instrument_height"],
-                #"nominal_instrument_depth": dsattrs["nominal_instrument_depth"],
-                "height_depth_units": "m",
-                #"sensor_type": dsattrs["INST_TYPE"],
+                # "serial_number": sn,
+                # "initial_instrument_height": dsattrs["initial_instrument_height"],
+                # "nominal_instrument_depth": dsattrs["nominal_instrument_depth"],
+                # "height_depth_units": "m",
+                # "sensor_type": dsattrs["INST_TYPE"],
             }
         )
 
-    #if utils.is_cf(ds):
+    # if utils.is_cf(ds):
     #    ds.attrs["featureType"] = "timeSeriesProfile"
 
     # Update attributes for EPIC and STG compliance
@@ -898,9 +904,9 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
     if "u_1205" in ds:
         ds["u_1205"].attrs.update(
             {
-                "name": "u",
+                # "name": "u",
                 "long_name": "Eastward Velocity",
-                #"generic_name": "u",
+                # "generic_name": "u",
                 "epic_code": 1205,
             }
         )
@@ -908,9 +914,9 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
     if "v_1206" in ds:
         ds["v_1206"].attrs.update(
             {
-                "name": "v",
+                # "name": "v",
                 "long_name": "Northward Velocity",
-                #"generic_name": "v",
+                # "generic_name": "v",
                 "epic_code": 1206,
             }
         )
@@ -918,9 +924,9 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
     if "w_1204" in ds:
         ds["w_1204"].attrs.update(
             {
-                "name": "w",
+                # "name": "w",
                 "long_name": "Vertical Velocity",
-                #"generic_name": "w",
+                # "generic_name": "w",
                 "epic_code": 1204,
             }
         )
@@ -929,10 +935,10 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
         ds["AGC_1202"].attrs.update(
             {
                 "units": "counts",
-                "name": "AGC",
+                # "name": "AGC",
                 "long_name": "Average Echo Intensity",
                 "generic_name": "AGC",
-                #"epic_code": 1202,
+                # "epic_code": 1202,
             }
         )
 
@@ -956,7 +962,7 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
                 {
                     "units": "m s-1",
                     "long_name": "Beam 1 Velocity",
-                    #"generic_name": "vel1",
+                    # "generic_name": "vel1",
                     "epic_code": 1277,
                 }
             )
@@ -965,7 +971,7 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
                 {
                     "units": "m s-1",
                     "long_name": "Beam 2 Velocity",
-                    #"generic_name": "vel2",
+                    # "generic_name": "vel2",
                     "epic_code": 1278,
                 }
             )
@@ -974,7 +980,7 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
                 {
                     "units": "m s-1",
                     "long_name": "Beam 3 Velocity",
-                    #"generic_name": "vel3",
+                    # "generic_name": "vel3",
                     "epic_code": 1279,
                 }
             )
@@ -984,7 +990,7 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
             {
                 "units": "counts",
                 "long_name": "Echo Intensity (AGC) Beam 1",
-                #"generic_name": "AGC1",
+                # "generic_name": "AGC1",
                 "epic_code": 1221,
             }
         )
@@ -994,7 +1000,7 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
             {
                 "units": "counts",
                 "long_name": "Echo Intensity (AGC) Beam 2",
-                #"generic_name": "AGC2",
+                # "generic_name": "AGC2",
                 "epic_code": 1222,
             }
         )
@@ -1004,7 +1010,7 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
             {
                 "units": "counts",
                 "long_name": "Echo Intensity (AGC) Beam 3",
-                #"generic_name": "AGC3",
+                # "generic_name": "AGC3",
                 "epic_code": 1223,
             }
         )
@@ -1012,16 +1018,17 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
     ds["P_1"].attrs.update(
         {
             "units": "dbar",
-            "name": "P",
+            # "name": "P",
             "long_name": "Uncorrected pressure",
-            #"generic_name": "depth",
+            # "generic_name": "depth",
             "epic_code": 1,
         }
     )  # TODO: is this generic name correct?
 
     if "P_1ac" in ds:
         ds["P_1ac"].attrs.update(
-            {"units": "dbar", "name": "Pac", "long_name": "Corrected pressure"}
+            # {"units": "dbar", "name": "Pac", "long_name": "Corrected pressure"}
+            {"units": "dbar", "long_name": "Corrected pressure"}
         )
         if "P_1ac_note" in ds.attrs:
             ds["P_1ac"].attrs.update({"note": ds.attrs["P_1ac_note"]})
@@ -1034,7 +1041,8 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
 
     if "bin_depth" in ds:
         ds["bin_depth"].attrs.update(
-            {"units": "m", "name": "bin depth", "long_name": "bin depth"}
+            # {"units": "m", "name": "bin depth", "long_name": "bin depth"}
+            {"units": "m", "long_name": "bin depth"}
         )
 
         if "P_1ac" in ds:
@@ -1059,9 +1067,9 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
     ds["Tx_1211"].attrs.update(
         {
             "units": "C",
-            "name": "Tx",
+            # "name": "Tx",
             "long_name": "Instrument Internal Temperature",
-            #"generic_name": "temp",
+            # "generic_name": "temp",
             "epic_code": 1211,
         }
     )
@@ -1069,9 +1077,9 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
     ds["Hdg_1215"].attrs.update(
         {
             "units": "degrees",
-            "name": "Hdg",
+            # "name": "Hdg",
             "long_name": "Instrument Heading",
-            #"generic_name": "hdg",
+            # "generic_name": "hdg",
             "epic_code": 1215,
         }
     )
@@ -1092,9 +1100,9 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
     ds["Ptch_1216"].attrs.update(
         {
             "units": "degrees",
-            "name": "Ptch",
+            # "name": "Ptch",
             "long_name": "Instrument Pitch",
-            #"generic_name": "ptch",
+            # "generic_name": "ptch",
             "epic_code": 1216,
         }
     )
@@ -1102,9 +1110,9 @@ def ds_add_attrs(ds, waves=False, inst_type="AQD"):
     ds["Roll_1217"].attrs.update(
         {
             "units": "degrees",
-            "name": "Roll",
+            # "name": "Roll",
             "long_name": "Instrument Roll",
-            #"generic_name": "roll",
+            # "generic_name": "roll",
             "epic_code": 1217,
         }
     )

--- a/stglib/aqd/aqdutils.py
+++ b/stglib/aqd/aqdutils.py
@@ -200,7 +200,7 @@ def swap_bindist_to_depth(ds):
 
 def set_orientation(VEL, T):
     """
-    Create z variable depending on instrument orientation
+    Create T variable depending on instrument orientation
     """
     """
     if "Pressure_ac" in VEL:

--- a/stglib/aqd/cdf2nc.py
+++ b/stglib/aqd/cdf2nc.py
@@ -130,10 +130,10 @@ def cdf_to_nc(cdf_filename, atmpres=False):
 
     VEL = utils.add_standard_names(VEL)
 
-    for var in VEL.variables:
-        if (var not in VEL.coords) and ("time" not in var):
+    #for var in VEL.variables:
+    #    if (var not in VEL.coords) and ("time" not in var):
             # cast as float32
-            VEL = utils.set_var_dtype(VEL, var)
+            #VEL = utils.set_var_dtype(VEL, var)
 
     if "prefix" in VEL.attrs:
         nc_filename = VEL.attrs["prefix"] + VEL.attrs["filename"] + "-a.nc"

--- a/stglib/aqd/cdf2nc.py
+++ b/stglib/aqd/cdf2nc.py
@@ -19,10 +19,10 @@ def cdf_to_nc(cdf_filename, atmpres=False):
     # VEL = utils.create_water_depth(VEL)
     VEL = utils.create_nominal_instrument_depth(VEL)
 
-    # Create depth variable depending on orientation
+    # create T depending on orientation
     VEL, T, T_orig = aqdutils.set_orientation(VEL, VEL["TransMatrix"].values)
 
-    # add z coordinate dim
+    # add z coordinate dim using core.utils.py def
     VEL = utils.create_z(VEL)
 
     # Transform coordinates from, most likely, BEAM to ENU

--- a/stglib/aqd/cdf2nc.py
+++ b/stglib/aqd/cdf2nc.py
@@ -22,6 +22,9 @@ def cdf_to_nc(cdf_filename, atmpres=False):
     # Create depth variable depending on orientation
     VEL, T, T_orig = aqdutils.set_orientation(VEL, VEL["TransMatrix"].values)
 
+    # add z coordinate dim
+    VEL = utils.create_z(VEL)
+
     # Transform coordinates from, most likely, BEAM to ENU
 
     if "VEL1" in VEL:
@@ -130,10 +133,10 @@ def cdf_to_nc(cdf_filename, atmpres=False):
 
     VEL = utils.add_standard_names(VEL)
 
-    #for var in VEL.variables:
+    # for var in VEL.variables:
     #    if (var not in VEL.coords) and ("time" not in var):
-            # cast as float32
-            #VEL = utils.set_var_dtype(VEL, var)
+    # cast as float32
+    # VEL = utils.set_var_dtype(VEL, var)
 
     if "prefix" in VEL.attrs:
         nc_filename = VEL.attrs["prefix"] + VEL.attrs["filename"] + "-a.nc"

--- a/stglib/core/utils.py
+++ b/stglib/core/utils.py
@@ -280,7 +280,7 @@ def add_standard_names(ds):
         "Ptch_1216": "platform_pitch",
         "Roll_1217": "platform_roll",
         "P_1": "sea_water_pressure",
-        "Tx_1211": "sea_water_temperature",
+        #"Tx_1211": "sea_water_temperature",
         "P_1ac": "sea_water_pressure_due_to_sea_water",
         "u_1205": "eastward_sea_water_velocity",
         "v_1206": "northward_sea_water_velocity",
@@ -308,13 +308,13 @@ def add_standard_names(ds):
             if f"AnalogInput2_{v}" in ds.attrs:
                 ds["AnalogInput2"].attrs[v] = ds.attrs[f"AnalogInput2_{v}"]
 
-    ds["feature_type_instance"] = xr.DataArray(
-        [f"{ds.attrs['MOORING']}aqd"], dims="feature_type_instance"
-    )
-    ds["feature_type_instance"].attrs["cf_role"] = "timeseries_id"
+    #ds["feature_type_instance"] = xr.DataArray(
+    #    [f"{ds.attrs['MOORING']}aqd"], dims="feature_type_instance"
+    #)
+    #ds["feature_type_instance"].attrs["cf_role"] = "timeseries_id"
 
-    for k in ds.data_vars:
-        ds[k].attrs["coverage_content_type"] = "physicalMeasurement"
+    #for k in ds.data_vars:
+    #    ds[k].attrs["coverage_content_type"] = "physicalMeasurement"
 
     return ds
 

--- a/stglib/core/utils.py
+++ b/stglib/core/utils.py
@@ -266,6 +266,7 @@ def ds_coord_no_fillvalue(ds):
         "sample",
         "frequency",
         "z",
+        "bindist",
     ]:
         if var in ds:
             ds[var].encoding["_FillValue"] = None
@@ -280,7 +281,7 @@ def add_standard_names(ds):
         "Ptch_1216": "platform_pitch",
         "Roll_1217": "platform_roll",
         "P_1": "sea_water_pressure",
-        #"Tx_1211": "sea_water_temperature",
+        # "Tx_1211": "sea_water_temperature",
         "P_1ac": "sea_water_pressure_due_to_sea_water",
         "u_1205": "eastward_sea_water_velocity",
         "v_1206": "northward_sea_water_velocity",
@@ -308,12 +309,12 @@ def add_standard_names(ds):
             if f"AnalogInput2_{v}" in ds.attrs:
                 ds["AnalogInput2"].attrs[v] = ds.attrs[f"AnalogInput2_{v}"]
 
-    #ds["feature_type_instance"] = xr.DataArray(
+    # ds["feature_type_instance"] = xr.DataArray(
     #    [f"{ds.attrs['MOORING']}aqd"], dims="feature_type_instance"
-    #)
-    #ds["feature_type_instance"].attrs["cf_role"] = "timeseries_id"
+    # )
+    # ds["feature_type_instance"].attrs["cf_role"] = "timeseries_id"
 
-    #for k in ds.data_vars:
+    # for k in ds.data_vars:
     #    ds[k].attrs["coverage_content_type"] = "physicalMeasurement"
 
     return ds

--- a/stglib/eofe.py
+++ b/stglib/eofe.py
@@ -172,6 +172,8 @@ def cdf_to_nc(cdf_filename):
     # assign min/max
     ds = utils.add_min_max(ds)
 
+    ds = utils.ds_coord_no_fillvalue(ds)
+
     nc_filename = ds.attrs["filename"] + "-a.nc"
 
     # ds['time']=ds['time'].astype('datetime64[s]')
@@ -365,7 +367,9 @@ def ds_add_attrs(ds):
     # modified from exo.ds_add_attrs
     ds = utils.ds_coord_no_fillvalue(ds)
 
-    ds["time"].attrs.update({"standard_name": "time", "axis": "T"})
+    ds["time"].attrs.update(
+        {"standard_name": "time", "axis": "T", "long_name": "time (UTC)"}
+    )
 
     ds["sample"].attrs.update({"units": "1", "long_name": "Sample in burst"})
 
@@ -373,9 +377,9 @@ def ds_add_attrs(ds):
         {
             "units": "1",
             "long_name": "Burst number",
-            "generic_name": "record",
-            "epic_code": "1207",
-            "coverage_content_type": "physicalMeasurement",
+            # "generic_name": "record",
+            # "epic_code": "1207",
+            # "coverage_content_type": "physicalMeasurement",
         }
     )
 
@@ -383,7 +387,7 @@ def ds_add_attrs(ds):
         {
             "units": "degree_C",
             "long_name": "Instrument Internal Temperature",
-            "standard_name": "sea_water_temperature",
+            # "standard_name": "sea_water_temperature",
             "epic_code": "1211",
         }
     )
@@ -393,7 +397,7 @@ def ds_add_attrs(ds):
             {
                 "units": "counts",
                 "long_name": "Average Echo Intensity",
-                "generic_name": "AGC",
+                # "generic_name": "AGC",
                 "epic_code": "1202",
             }
         )
@@ -425,7 +429,9 @@ def ds_add_attrs(ds):
             }
         )
 
+    """
     # add initial height information and fill values to variabels
+
     def add_attributes(var, dsattrs):
         if "ea" in dsattrs["instrument_type"]:
             var.attrs.update(
@@ -443,11 +449,17 @@ def ds_add_attrs(ds):
                     "sensor_type": "ECHOLOGGER AA400",
                 }
             )
-
+    
     # don't include all attributes for coordinates that are also variables
-    for var in ds.variables:
-        if (var not in ds.coords) and ("time" not in var):
-            add_attributes(ds[var], ds.attrs)
+    #for var in ds.variables:
+    #    if (var not in ds.coords) and ("time" not in var):
+    #        add_attributes(ds[var], ds.attrs)
+    """
+    # rename instrument_type for global attributes
+    if "aa" in ds.attrs["instrument_type"]:
+        ds.attrs["instrument_type"] = "EofE ECHOLOGGER AA400 altimeter"
+    elif "ea" in ds.attrs["instrument_type"]:
+        ds.attrs["instrument_type"] = "EofE ECHOLOGGER EA400 profiling altimeter"
 
     return ds
 

--- a/stglib/exo.py
+++ b/stglib/exo.py
@@ -378,9 +378,12 @@ def ds_add_attrs(ds):
 
     if "Fch_906" in ds:
         ds["Fch_906"].attrs.update(
-            {"units": "ug/L", "long_name": "Chlorophyll A", "epic_code": 906,
-             "standard_name": "mass_concentration_of_chlorophyll_in_sea_water",
-             "comments": "from calibration of sensor with rhodamine W/T in lab"
+            {
+                "units": "ug/L",
+                "long_name": "Chlorophyll A",
+                "epic_code": 906,
+                "standard_name": "mass_concentration_of_chlorophyll_in_sea_water",
+                "comments": "from calibration of sensor with rhodamine W/T in lab",
             }
         )
 
@@ -529,9 +532,9 @@ def ds_add_attrs(ds):
             }
         )
 
-    for var in ds.variables:
-        if (var not in ds.coords) and ("time" not in var):
-            add_attributes(ds[var], ds.attrs)
+    # for var in ds.variables:
+    #    if (var not in ds.coords) and ("time" not in var):
+    #        add_attributes(ds[var], ds.attrs)
 
     return ds
 
@@ -549,10 +552,10 @@ def read_exo_header(filnam, encoding="utf-8"):
                 header[v[0]] = {}
                 header[v[0]]["sensor_serial_number"] = v[1]
                 if v[0] == "Battery V":
-                    header["serial_number"]=v[1]
+                    header["serial_number"] = v[1]
 
-        #if "serial_number" not in header:
-            # get instrument SN from filename -- this will fail on files not named according to the Kor default file-naming convention but I'm not sure how else to get it
+        # if "serial_number" not in header:
+        # get instrument SN from filename -- this will fail on files not named according to the Kor default file-naming convention but I'm not sure how else to get it
         #    header["serial_number"] = filnam.split("/")[-1].split("_")[1]
 
     except (pd.errors.ParserError, KeyError):
@@ -580,7 +583,7 @@ def read_exo_header(filnam, encoding="utf-8"):
                 header[var]["data_columns"] = [
                     int(x) for x in vals.values[0][3].split(";")
                 ]
-       
+
     return header
 
 


### PR DESCRIPTION
Clean-up and remove inconsistencies in attributes for Aquadopps (Nortek), D|waves (RBR), Exos (YSI), ECO-NTUs (Wet Labs), and EA400 (EofE). Where possible common code was utilized in core/utils.py. For now code has been commented out (using both line and block commenting), that is no longer used as part of these changes. If changes are accepted and it is desired, I can remove those commented out parts of the code prior to merging. 