### PR TITLE
add trim by stddev ratio

### DIFF
--- a/stglib/core/qaqc.py
+++ b/stglib/core/qaqc.py
@@ -196,19 +196,27 @@ def trim_by_any(ds, var):
 
 
 def trim_max_std(ds, var):
-    if var + "_std_max" in ds.attrs:
-        print(
-            "%s: Trimming using maximum standard deviation of %f"
-            % (var, ds.attrs[var + "_std_max"])
-        )
-        ds[var][ds["Turb_std"] > ds.attrs[var + "_std_max"]] = np.nan
+    if var + "_max_std" in ds.attrs:
+        if var + "_std" in ds.data_vars:  # check to see that std var exists
+            print(
+                "%s: Trimming using maximum standard deviation of %f"
+                % (var, ds.attrs[var + "_max_std"])
+            )
 
-        notetxt = (
-            "Values filled where standard deviation greater than %f "
-            "units. " % ds.attrs[var + "_std_max"]
-        )
+            varstd = var + "_std"
+            ds[var][ds[varstd] > ds.attrs[var + "_max_std"]] = np.nan
 
-        ds = utils.insert_note(ds, var, notetxt)
+            notetxt = (
+                "Values filled where standard deviation greater than %f "
+                "units. " % ds.attrs[var + "_max_std"]
+            )
+
+            ds = utils.insert_note(ds, var, notetxt)
+
+        else:
+            print(
+                f"{var}_std does not exist was NOT able to trim using maximum standard deviation method"
+            )
 
     return ds
 
@@ -311,5 +319,32 @@ def trim_maxabs_diff(ds, var):
         )
 
         ds = utils.insert_note(ds, var, notetxt)
+
+    return ds
+
+
+def trim_std_ratio(ds, var):
+    """trim values using ratio of standard deviation value to variable value (requires var_std to exists)"""
+    if var + "_std_ratio" in ds.attrs:
+        if var + "_std" in ds.data_vars:  # check to see that std var exists
+            print(
+                "%s: Trimming using standard deviation ratio of %f"
+                % (var, ds.attrs[var + "_std_ratio"])
+            )
+
+            varstd = var + "_std"
+            ds[var][ds[varstd] / ds[var] > ds.attrs[var + "_std_ratio"]] = np.nan
+
+            notetxt = (
+                "Values filled where standard deviation ratio threshold of %f was exceeded"
+                % (ds.attrs[var + "_std_ratio"])
+            )
+
+            ds = utils.insert_note(ds, var, notetxt)
+
+        else:
+            print(
+                f"{var}_std does not exist was NOT able to trim using standard deviation ratio method"
+            )
 
     return ds

--- a/stglib/eco.py
+++ b/stglib/eco.py
@@ -285,8 +285,10 @@ def eco_qaqc(ds):
 
             ds = qaqc.trim_bad_ens(ds, var)
 
+            ds = qaqc.trim_std_ratio(ds, var)
+
         # after check for masking vars by others
-        for var in ["Turb"]:
+        for var in ["Turb", "Turb_std"]:
             ds = qaqc.trim_mask(ds, var)
 
     return ds

--- a/stglib/tests/data/11032Decn_config.yaml
+++ b/stglib/tests/data/11032Decn_config.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2b5cfa40aecb897f642a3947c9ffa0f69d1484123d9bc6426256dd43dfd21a43
-size 690
+oid sha256:937663b3e2432f73ef5a1b4c001346d68b0a7e194c195a7e45f9f9935265c13a
+size 751


### PR DESCRIPTION
Add ability to trim variables with companion standard deviation variables using user threshold for the ratio of standard deviation to variable value. Made generic so will work when invoked as long as there is a companion variable in the dataset with name format var + "_std". Also fixed issue with existing trim_max_std function and made it non-specific as well (previously had "Turb_std" hard coded).