### PR TITLE
rbrcontncout

### DIFF
--- a/stglib/rsk/cdf2nc.py
+++ b/stglib/rsk/cdf2nc.py
@@ -90,7 +90,7 @@ def cdf_to_nc(cdf_filename, atmpres=None, writefile=True, format="NETCDF4"):
         elif (ds.attrs["sample_mode"] == "CONTINUOUS") and (
             "burst" not in ds or "sample" not in ds
         ):
-            nc_filename = ds.attrs["filename"] + "-cal.nc"
+            nc_filename = ds.attrs["filename"] + "cont-cal.nc"
 
         else:
             nc_filename = ds.attrs["filename"] + "-a.nc"
@@ -132,10 +132,9 @@ def trim_min(ds, var):
 
         if "sample" in ds:
             bads = (ds[var] < ds.attrs[var + "_min"]).any(dim="sample")
+            ds[var][bads, :] = np.nan
         else:
-            bads = (ds[var] < ds.attrs[var + "_min"]).any(dim="time")
-
-        ds[var][bads, :] = np.nan
+            ds[var][ds[var] < ds.attrs[var + "_min"]] = np.nan
 
         notetxt = "Values filled where less than %f units. " % ds.attrs[var + "_min"]
 

--- a/stglib/rsk/csv2cdf.py
+++ b/stglib/rsk/csv2cdf.py
@@ -103,6 +103,7 @@ def csv_to_cdf(metadata):
         ds = ds.drop("P_1")
         ds = xr.merge([ds, dsburst])
 
+    """
     # Set burst interval, [sec], USER DEFINED in instrument attr for continuous mode sampling
     if (ds.attrs["sample_mode"] == "CONTINUOUS") and ("wave_interval" in ds.attrs):
         # wave_interval is [sec] interval for wave statistics for continuous data
@@ -139,6 +140,7 @@ def csv_to_cdf(metadata):
         ds = ds.rename({"time": "timeold"})
         ds = ds.rename({"timenew": "time"})
         ds = ds.drop("timeold")
+    """
 
     ds = utils.shift_time(ds, 0)
 


### PR DESCRIPTION
Add ability to write out the continuous RBR data to CF netCDF file and also preserve shaping of continuous data into wave burst if wave_interval attribute is specified and write out CF netCDF file for both in a single workflow. Had to make coordinate variable "time" a dtype = "double" for continuous data netCDF file (+ 'cont-cal.nc'), since int64 not allowed currently . Also edited rsk/cdf2nc.trim_min to handle when no sample dim exists (i.e. for continuous data). New code was tested on 2 separate datasets (1 using virtuosos D|fast 12 and other solo3d), and test_scripts.py was run to make sure code was not broken with existing tests/data.