### PR TITLE
Add Signature Support Docs

### DIFF
--- a/doc/config.rst
+++ b/doc/config.rst
@@ -80,6 +80,19 @@ Aquadopp-specific options include:
    :language: yaml
    :linenos:
 
+Signature
+--------
+
+Signature-specific options include (see Aquadopp for others):
+
+- ``outdir``: output directory (make sure it exists) to write individual ``cdf`` files before being compiled into a single ``cdf`` file per data type
+- ``orientation``: can be ``UP`` or ``DOWN`` use this to identify orientation of profiler
+- ``head_rotation``: probably will be ``'horizontal'``
+
+.. literalinclude:: ../examples/aqd_config.yaml
+   :language: yaml
+   :linenos:
+   
 d|wave
 ------
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,6 +18,7 @@ Currently, this package has at least partial support for:
 
 - Nortek Aquadopp profilers, in mean-current and wave-burst modes
 - Nortek Vector velocimeters
+- Nortek Signature profilers
 - RBR pressure (including waves) and turbidity sensors
 - YSI EXO2 water-quality sondes
 - SonTek IQ flow monitors
@@ -34,7 +35,6 @@ Currently, this package has at least partial support for:
 We have plans to support:
 
 - Nortek Aquadopp profiles in HR mode
-- Nortek Signature profilers
 - RDI Sentinel V profilers
 
 .. toctree::
@@ -48,6 +48,7 @@ We have plans to support:
    aqd
    wvs
    vec
+   sig
    rsk
    exo
    iq

--- a/doc/sig.rst
+++ b/doc/sig.rst
@@ -1,0 +1,34 @@
+Signature
+******
+
+Data will generally be processed using a series of run scripts that use command line arguments.
+
+**NOTE: this code works with up- or down-looking Signature data collected in 'beam', 'XYZ' or 'earth'.
+It supports data types Burst, IBurst, Echo1, BurstHR, and IBurstHR. It also supports Altimeter and AHRS (Advanced Heading Reference System) data that are included when present with supported data types. Presently it does not yet support data types Average and BottomTrack, but they will be added in the future as needed.**
+
+Instrument data to raw .cdf
+===========================
+
+First, export data from the Signature Deployment software to Matlab format with coordinate transformations.
+
+Convert from mat files to a raw netCDF file (for each data type) with ``.cdf`` extension using runsigmat2cdf.py. This script
+depends on two arguments, the global attribute file and extra configuration information :doc:`configuration files </config>`.
+
+runsigmat2cdf.py
+----------------
+
+.. argparse::
+   :ref: stglib.core.cmd.sigmat2cdf_parser
+   :prog: runsigmat2cdf.py
+
+Raw .cdf to CF-compliant .nc
+============================
+
+Convert the raw .cdf data (for each data type) into an CF-compliant netCDF file with .nc extension, optionally including :doc:`atmospheric correction </atmos>` of the pressure data.  Correcting pressure for atmospheric is a side-bar task- use the .ipynb examples to see what to do.
+
+runsigcdf2nc.py
+---------------
+
+.. argparse::
+   :ref: stglib.core.cmd.sigcdf2nc_parser
+   :prog: runsigcdf2nc.py


### PR DESCRIPTION
Add and update docs for Signature Support. I was unable to built the docs locally. There was an extension error running sphinx (see below).

(stglib-docs) C:\Users\ssuttles\Git\stglib\doc>make html
Running Sphinx v5.0.2
[autosummary] generating autosummary for: aqd.rst, atmos.rst, code.rst, config.rst, contributing.rst, eofe.rst, exo.rst, hobo.rst, index.rst, indexvel.rst, install.rst, iq.rst, overview.rst, rsk.rst, sig.rst, turnaround.rst, vec.rst, wet.rst, wvs.rst, wxt.rst

 

Extension error (sphinx.ext.autosummary):
Handler <function process_generate_options at 0x000002BF905A5EA0> for event 'builder-inited' threw an exception (exception: no module named stglib.aqd.cdf2nc)