### PR TITLE
adding and removing PATH variables automatically during pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,8 @@ setup(
         "console_scripts": [
             "runsigmat2cdf=stglib.core.cmd:runsigmat2cdf",
             "runsigcdf2nc=stglib.core.cmd:runsigcdf2nc",
+            'post_install_script = post_install:update_path',
+            'pre_uninstall_script = pre_uninstall:remove_from_path',
         ],
     },
     include_package_data=True,

--- a/stglib/post_install.py
+++ b/stglib/post_install.py
@@ -1,8 +1,9 @@
 import os
+from pathlib import Path
 
 def update_path():
     package_dir = os.path.dirname(os.path.abspath(__file__))
-    new_path = os.path.join(package_dir, '..', '..', '..', 'scripts')
+    new_path = str(Path(package_dir).parents[3].joinpath('scripts'))
 
     # Modify the PATH environment variable
     os.environ['PATH'] = f"{new_path}:{os.environ['PATH']}"

--- a/stglib/post_install.py
+++ b/stglib/post_install.py
@@ -1,0 +1,8 @@
+import os
+
+def update_path():
+    package_dir = os.path.dirname(os.path.abspath(__file__))
+    new_path = os.path.join(package_dir, '..', '..', '..', 'scripts')
+
+    # Modify the PATH environment variable
+    os.environ['PATH'] = f"{new_path}:{os.environ['PATH']}"

--- a/stglib/pre_uninstall.py
+++ b/stglib/pre_uninstall.py
@@ -1,0 +1,10 @@
+import os
+
+def remove_from_path():
+    package_dir = os.path.dirname(os.path.abspath(__file__))
+    path_to_remove = os.path.join(package_dir, '..', '..', '..', scripts')
+
+    # Remove the package directory from the PATH environment variable
+    paths = os.environ['PATH'].split(':')
+    paths = [path for path in paths if path != path_to_remove]
+    os.environ['PATH'] = ':'.join(paths)

--- a/stglib/pre_uninstall.py
+++ b/stglib/pre_uninstall.py
@@ -1,8 +1,9 @@
 import os
+from pathlib import Path
 
 def remove_from_path():
     package_dir = os.path.dirname(os.path.abspath(__file__))
-    path_to_remove = os.path.join(package_dir, '..', '..', '..', scripts')
+    path_to_remove = str(Path(package_dir).parents[3].joinpath('scripts'))
 
     # Remove the package directory from the PATH environment variable
     paths = os.environ['PATH'].split(':')


### PR DESCRIPTION
These changes should apply when pip install is used  so that the CLI commands should run without a need for the path to scripts folder. Looks like conda install requires another set of changes. For now, I am going to create this PR just to capture what I have done so far. 

I think the other option of using entry points in setup.py will require updating the scripts to have an entry point such as a function. For example `runsigcdf2nc.py` would have a 

```
#!/usr/bin/env python
import stglib

    def runsigcdf2nc():
    ...
...
``` 
That's probably why the following changes to setup.py are not working at the moment There is no entry point ":runsigcdf2nc".  

```
entry_points={
    "console_scripts": [
        "runsigcdf2nc=stglib.core.cmd:runsigcdf2nc",
...
```
In that case running them with module execution with import should also work as an alternative according to the explanation [here](https://stackoverflow.com/a/62923810/2033057): 

`python -m stglib.runsigcdf2nc 11261sig_burst-raw.cdf
`
 