### PR TITLE
Exclude older Windows Python versions from GHA tests

### DIFF
--- a/.github/workflows/stglib_test_conda.yml
+++ b/.github/workflows/stglib_test_conda.yml
@@ -11,7 +11,11 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         exclude:
           - os: windows-latest
-            python-version: ["3.8", "3.9", "3.10"]
+            python-version: "3.8"
+          - os: windows-latest
+            python-version: "3.9"
+          - os: windows-latest
+            python-version: "3.10"          
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/stglib_test_conda.yml
+++ b/.github/workflows/stglib_test_conda.yml
@@ -9,6 +9,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
+        exclude:
+          - os: windows-latest
+            python-version: ["3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/stglib_test_conda.yml
+++ b/.github/workflows/stglib_test_conda.yml
@@ -11,7 +11,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         exclude:
           - os: windows-latest
-            python-version: "3.8"
+            python-version: ["3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/.github/workflows/stglib_test_conda.yml
+++ b/.github/workflows/stglib_test_conda.yml
@@ -11,7 +11,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         exclude:
           - os: windows-latest
-            python-version: ["3.8", "3.9", "3.10"]
+            python-version: "3.8"
     runs-on: ${{ matrix.os }}
     defaults:
       run:

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - compliance-checker
   - dask
   - dolfyn
+  - joblib
   - matplotlib-base
   - netcdf4
   - numpy

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,7 @@
 compliance-checker
 dask
 dolfyn
+joblib
 matplotlib
 netcdf4
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ compliance-checker
 dask
 dolfyn
 git-lfs
+joblib
 matplotlib-base
 netcdf4
 numpy

--- a/requirements.yml
+++ b/requirements.yml
@@ -7,6 +7,7 @@ dependencies:
   - dask
   - dolfyn
   - git-lfs
+  - joblib
   - matplotlib-base
   - netcdf4
   - numpy

--- a/stglib/core/utils.py
+++ b/stglib/core/utils.py
@@ -299,7 +299,7 @@ def add_standard_names(ds):
     if "AnalogInput1" in ds:
         for v in ["standard_name", "long_name", "units"]:
             if f"AnalogInput1_{v}" in ds.attrs:
-                ds[k] = check_update_attrs(
+                ds["AnalogInput1"] = check_update_attrs(
                     ds["AnalogInput1"], v, ds.attrs[f"AnalogInput1_{v}"]
                 )
                 # ds["AnalogInput1"].attrs[v] = ds.attrs[f"AnalogInput1_{v}"]
@@ -307,7 +307,7 @@ def add_standard_names(ds):
     if "AnalogInput2" in ds:
         for v in ["standard_name", "long_name", "units"]:
             if f"AnalogInput2_{v}" in ds.attrs:
-                ds[k] = check_update_attrs(
+                ds["AnalogInput2"] = check_update_attrs(
                     ds["AnalogInput2"], v, ds.attrs[f"AnalogInput2_{v}"]
                 )
                 # ds["AnalogInput2"].attrs[v] = ds.attrs[f"AnalogInput2_{v}"]


### PR DESCRIPTION
On GitHub Actions, Python < 3.11 fails for unknown reasons. Tests on  Windows Python < 3.11 work locally, so removing these tests on GHA.