### PR TITLE
add imports to nc2wave.py and cont dwave test

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,6 @@
 *.ipynb filter=nbstripout
-
 *.ipynb diff=ipynb
 stglib/_version.py export-subst
+stglib/tests/data/055109_20220808_1605.zip filter=lfs diff=lfs merge=lfs -text
+stglib/tests/data/055109_20220808_1605_config.yaml filter=lfs diff=lfs merge=lfs -text
+stglib/tests/data/gatts_055109_20220808_1605.txt filter=lfs diff=lfs merge=lfs -text

--- a/stglib/rsk/nc2waves.py
+++ b/stglib/rsk/nc2waves.py
@@ -1,5 +1,6 @@
 import numpy as np
 import xarray as xr
+
 from ..core import utils, waves
 
 

--- a/stglib/rsk/nc2waves.py
+++ b/stglib/rsk/nc2waves.py
@@ -1,3 +1,5 @@
+import numpy as np
+import xarray as xr
 from ..core import utils, waves
 
 

--- a/stglib/tests/data/055109_20220808_1605.zip
+++ b/stglib/tests/data/055109_20220808_1605.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a628bdedbaa479ff75234c8890e0ea698ab49b3c6b51ebc92ef29f3148da7820
+size 4182388

--- a/stglib/tests/data/055109_20220808_1605_config.yaml
+++ b/stglib/tests/data/055109_20220808_1605_config.yaml
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4a4498cfd32f69c5e24298764f0051acca3b36a03948c14a441f78f6d466c64c
+size 193

--- a/stglib/tests/data/gatts_055109_20220808_1605.txt
+++ b/stglib/tests/data/gatts_055109_20220808_1605.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d285acd9d247bb366b628a261d72291856d497319210e02067e311b64ea9003
+size 759

--- a/stglib/tests/test_scripts.py
+++ b/stglib/tests/test_scripts.py
@@ -202,6 +202,15 @@ def rbr_nc(nc_file):
     assert "Done writing netCDF file" in result.stdout.decode("utf8")
 
 
+def rbr_wvs(nc_file):
+    result = subprocess.run(
+        [scripts / "runrsknc2waves.py", nc_file],
+        capture_output=True,
+        cwd="stglib/tests/data",
+    )
+    assert "Done writing netCDF file" in result.stdout.decode("utf8")
+
+
 def test_rbr():
     import zipfile
     from os import path
@@ -212,6 +221,12 @@ def test_rbr():
         zip_ref.extractall("stglib/tests/data/")
     rbr_raw("gatts_CSF20SC2.txt", "csf20sc201_config.yaml")
     rbr_nc("CSF20SC201pt-raw.cdf")
+    rbr_wvs("CSF20SC201ptb-cal.nc")
+    with zipfile.ZipFile("stglib/tests/data/055109_20220808_1605.zip", "r") as zip_ref:
+        zip_ref.extractall("stglib/tests/data/")
+    rbr_raw("gatts_055109_20220808_1605.txt", "055109_20220808_1605_config.yaml")
+    rbr_nc("11512Cdw-raw.cdf")
+    rbr_wvs("11512Cdwcont-cal.nc")
 
 
 def eofe_raw(glob_att, config_yaml):


### PR DESCRIPTION
Added numpy and xarray imports to beginning of nc2waves.py as well as incorporating a continuous dwave dataset to the rsk test. 