### PR TITLE
Aqd agc slbins

### DIFF
--- a/stglib/aqd/aqdutils.py
+++ b/stglib/aqd/aqdutils.py
@@ -989,9 +989,15 @@ def ds_add_attrs(ds, waves=False, hr=False, inst_type="AQD"):
             "trim_method" in dsattrs
             and dsattrs["trim_method"].lower() == "water level sl"
         ):
+            if "sl_bins" in ds.attrs:
+                sltxt = ds.attrs["sl_bins"]
+            elif "sl_bins" not in ds.attrs:
+                sltxt = 0
             vel.attrs[
                 "note"
-            ] = "Velocity bins trimmed if out of water or if side lobes intersect sea surface"
+            ] = "Velocity bins trimmed if out of water or if side lobes intersect sea surface (with {} additional surface bins removed).".format(
+                sltxt
+            )
 
     def add_attributes(var, dsattrs):
         if inst_type == "AQD":

--- a/stglib/aqd/aqdutils.py
+++ b/stglib/aqd/aqdutils.py
@@ -1446,27 +1446,6 @@ def fill_agc(ds):
     if "agc_threshold" in ds.attrs:
         Ptxt = str(ds.attrs["agc_threshold"])
 
-        # fill beam velocities by corresponding beam AGC
-        ds["vel1_1277"] = ds["vel1_1277"].where(
-            ds["AGC1_1221"] > ds.attrs["agc_threshold"]
-        )
-        ds["vel2_1278"] = ds["vel2_1278"].where(
-            ds["AGC2_1222"] > ds.attrs["agc_threshold"]
-        )
-        ds["vel3_1279"] = ds["vel3_1279"].where(
-            ds["AGC3_1223"] > ds.attrs["agc_threshold"]
-        )
-
-        notetxt = (
-            "Data filled by corresponding beam AGC using threshold of %s counts. "
-            % (str(ds.attrs["agc_threshold"]))
-        )
-
-        vel = ["vel1_1277", "vel2_1278", "vel3_1279"]
-
-        for var in vel:
-            ds = utils.insert_note(ds, var, notetxt)
-
         # fill transformed u,v,w velocities by averaged AGC (AGC_1202)
         uvw = ["u_1205", "v_1206", "w_1204"]
 

--- a/stglib/aqd/aqdutils.py
+++ b/stglib/aqd/aqdutils.py
@@ -400,13 +400,22 @@ def trim_vel(ds, waves=False, data_vars=["U", "V", "W", "AGC"]):
             ds = utils.insert_history(ds, histtext)
 
         elif ds.attrs["trim_method"].lower() == "water level sl":
+            if "sl_bins" in ds.attrs:
+                sl_bins = ds.attrs["sl_bins"]
+                sltxt = ds.attrs["sl_bins"]
+            elif "sl_bins" not in ds.attrs:
+                sl_bins = 0
+                sltxt = 0
+
             for var in data_vars:
                 ds[var] = ds[var].where(
-                    ds["bindist"] < P * np.cos(np.deg2rad(ds.attrs["beam_angle"]))
+                    ds["bindist"]
+                    < (P * np.cos(np.deg2rad(ds.attrs["beam_angle"])))
+                    - (ds.attrs["bin_size"] * sl_bins)
                 )
 
-            histtext = "Trimmed velocity data using {} pressure (water level) and sidelobes.".format(
-                Ptxt
+            histtext = "Trimmed velocity data using {} pressure (water level) and sidelobes (with {} additional surface bins removed).".format(
+                Ptxt, sltxt
             )
 
             ds = utils.insert_history(ds, histtext)

--- a/stglib/aqd/cdf2nc.py
+++ b/stglib/aqd/cdf2nc.py
@@ -114,6 +114,9 @@ def cdf_to_nc(cdf_filename, atmpres=False):
         VEL = aqdutils.trim_single_bins(VEL, var)
         VEL = qaqc.trim_fliers(VEL, var)
 
+    # fill with AGC threshold
+    VEL = aqdutils.fill_agc(VEL)
+
     # after check for masking vars by other vars
     for var in VEL.data_vars:
         VEL = qaqc.trim_mask(VEL, var)


### PR DESCRIPTION
This PR includes 2 QAQC Aquadopp features in aqdutils:

1. Filling transformed velocities (u,v,w) by an AGC threshold. I did not include filling beam velocities (vel1,vel2,vel3) in the is feature. From what I'm noticing, the beam velocities are always left unfilled. 
2. Filling additional surface bins if trim_method 'water level sl' is not sufficient and some surface velocities are still bad throughout dataset. 

Let me know if you have any suggested changes to how I've written the code/naming of threshold attributes. 