### PR TITLE
remove 'name: Pac' attribute from exo and dwave p1ac

### DIFF
--- a/stglib/exo.py
+++ b/stglib/exo.py
@@ -510,7 +510,6 @@ def ds_add_attrs(ds):
         ds["P_1ac"].attrs.update(
             {
                 "units": "dbar",
-                "name": "Pac",
                 "long_name": "Corrected pressure",
                 "standard_name": "sea_water_pressure_due_to_sea_water",
             }

--- a/stglib/rsk/cdf2nc.py
+++ b/stglib/rsk/cdf2nc.py
@@ -176,7 +176,6 @@ def ds_add_attrs(ds):
     if "P_1ac" in ds:
         ds["P_1ac"].attrs.update(
             {
-                "name": "Pac",
                 "long_name": "Corrected pressure",
                 "standard_name": "sea_water_pressure_due_to_sea_water",
             }


### PR DESCRIPTION
As PR title states, changes have been made to exo.py and rsk/cdf2nc.py to remove 'name: Pac' in P_1ac variable attributes. 