### PR TITLE
Update vertical dimension handling

### DIFF
--- a/stglib/aqd/cdf2nc.py
+++ b/stglib/aqd/cdf2nc.py
@@ -87,8 +87,8 @@ def cdf_to_nc(cdf_filename, atmpres=False):
     #     if var in VEL:
     #         VEL = utils.add_lat_lon(VEL, var)
 
-    # swap_dims from bindist to depth
-    VEL = ds_swap_dims(VEL)
+    # swap vert dim to z or user specified in vert_dim
+    VEL = aqdutils.ds_swap_dims(VEL)
 
     # Rename DataArrays for EPIC compliance
     VEL = aqdutils.ds_rename(VEL)
@@ -156,18 +156,6 @@ def cdf_to_nc(cdf_filename, atmpres=False):
     print("Done writing netCDF file", nc_filename)
 
     return VEL
-
-
-def ds_swap_dims(ds):
-    # need to preserve z attrs because swap_dims will remove them
-    attrsbak = ds["z"].attrs
-    for v in ds.data_vars:
-        if "bindist" in ds[v].coords:
-            ds[v] = ds[v].swap_dims({"bindist": "z"})
-
-    ds["z"].attrs = attrsbak
-
-    return ds
 
 
 def ds_drop(ds):

--- a/stglib/aqd/hrcdf2nc.py
+++ b/stglib/aqd/hrcdf2nc.py
@@ -76,8 +76,8 @@ def cdf_to_nc(cdf_filename, atmpres=False):
 
     VEL = aqdutils.make_bin_depth(VEL)
 
-    # swap_dims from bindist to depth
-    VEL = ds_swap_dims(VEL)
+    # swap vert dim to z or user specified in vert_dim
+    VEL = aqdutils.ds_swap_dims(VEL)
 
     # Rename DataArrays for EPIC compliance
     VEL = aqdutils.ds_rename(VEL)
@@ -177,18 +177,6 @@ def cdf_to_nc(cdf_filename, atmpres=False):
     print("Done writing burst averaged netCDF file", nc_filename)
 
     return VEL
-
-
-def ds_swap_dims(ds):
-    # need to preserve z attrs because swap_dims will remove them
-    attrsbak = ds["z"].attrs
-    for v in ds.data_vars:
-        if "bindist" in ds[v].coords:
-            ds[v] = ds[v].swap_dims({"bindist": "z"})
-
-    ds["z"].attrs = attrsbak
-
-    return ds
 
 
 def ds_drop(ds):

--- a/stglib/eofe.py
+++ b/stglib/eofe.py
@@ -109,7 +109,7 @@ def cdf_to_nc(cdf_filename):
     ds = utils.create_z(ds)
 
     # swap bin dim with bin_height
-    ds = ds_swap_dims(ds)  # swap vert dim to z
+    ds = aqdutils.ds_swap_dims(ds)  # swap vert dim to z or user specified in vert_dim
 
     # rename variables
     ds = ds_rename_vars(ds)
@@ -736,36 +736,6 @@ def average_burst(ds):
 
     if "seabed_elevation" in ds:
         ds["seabed_elevation"] = ds["seabed_elevation"].round(3)
-
-    return ds
-
-
-def ds_swap_dims(
-    ds,
-):  # swap vert dim to z or dim specified by vert_dim in config yaml file
-    # need to preserve z attrs because swap_dims will remove them
-
-    if "vert_dim" in ds.attrs:
-        vdim = ds.attrs["vert_dim"]
-        attrsbak = ds[vdim].attrs
-        for v in ds.data_vars:
-            if "bins" in ds[v].coords:
-                ds[v] = ds[v].swap_dims({"bins": vdim})
-
-        ds[vdim].attrs = attrsbak
-
-        # axis attr set for z in utils.create_z so need to del if other than z
-        if ds.attrs["vert_dim"] != "z":
-            ds[vdim].attrs["axis"] = "Z"
-            del ds["z"].attrs["axis"]
-
-    else:  # set vert dim to z if not specifed
-        attrsbak = ds["z"].attrs
-        for v in ds.data_vars:
-            if "bins" in ds[v].coords:
-                ds[v] = ds[v].swap_dims({"bins": "z"})
-
-        ds["z"].attrs = attrsbak
 
     return ds
 

--- a/stglib/sig/cdf2nc.py
+++ b/stglib/sig/cdf2nc.py
@@ -92,8 +92,8 @@ def cdf_to_nc(cdf_filename, atmpres=False):
     ds = aqdutils.ds_rename(ds)  # for common variables
     ds = ds_drop(ds)
     ds = ds_rename_sig(ds)  # for signature vars not in aqds or vecs
-    # swap_dims from bindist to depth
-    ds = ds_swap_dims(ds)
+    # swap vert dim to z or user specified in vert_dim
+    ds = aqdutils.ds_swap_dims(ds)
 
     ds = utils.ds_add_lat_lon(ds)
 
@@ -308,18 +308,6 @@ def ds_rename_sig(ds, waves=False):
         if v in ds:
             ds = ds.drop_vars(v)
     """
-    return ds
-
-
-def ds_swap_dims(ds):
-    # need to preserve z attrs because swap_dims will remove them
-    attrsbak = ds["z"].attrs
-    for v in ds.data_vars:
-        if "bindist" in ds[v].coords:
-            ds[v] = ds[v].swap_dims({"bindist": "z"})
-
-    ds["z"].attrs = attrsbak
-
     return ds
 
 

--- a/stglib/tests/data/aqdhr1113tst_config.yaml
+++ b/stglib/tests/data/aqdhr1113tst_config.yaml
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:371e44e85cbb9b324f9f70e316194061479dcec4ef04e51c09f88f061ad6fc4a
-size 1345
+oid sha256:e57b49e39b354fbd6707d0c9b2f920096700051c7200f87255f184fb11278e6c
+size 1364


### PR DESCRIPTION
Add ds_swap_dims to aqdutils.py to handle user specified **vert_dim** option and invoke for AQD, AQDHR, Signatures, and eofe instruments. Delete versions of ds_swap_dims in instrument specific cdf2nc routines.