### PR TITLE
Update how to determine depth dimension

### DIFF
--- a/stglib/core/utils.py
+++ b/stglib/core/utils.py
@@ -1007,10 +1007,11 @@ def create_z(ds):
     # find depth dimension values
     # check for sea floor depth standard names
     sfds = ["geoid", "geopotential_datum", "mean_sea_level", "reference_ellipsoid"]
+    depvar = None
     for k in sfds:
         name = "sea_floor_depth_below_" + k
-        longname = "depth below " + k.replace("_", " ")
         if name in ds.attrs:
+            longname = "depth below " + k.replace("_", " ")
             if "bindist" in ds:
                 if ds.attrs["orientation"].upper() == "DOWN":
                     depvar = (
@@ -1026,9 +1027,8 @@ def create_z(ds):
                     )
             else:
                 depvar = ds.attrs[name] - ds.attrs["initial_instrument_height"]
-            break
 
-    if "depvar" not in locals():
+    if depvar is None:
         if "D_3" in ds:
             if "bindist" in ds:
                 if ds.attrs["orientation"].upper() == "DOWN":

--- a/stglib/core/utils.py
+++ b/stglib/core/utils.py
@@ -1004,35 +1004,27 @@ def create_z(ds):
     ds["z"].attrs["units"] = "m"
     ds["z"].attrs["standard_name"] = "height"
 
-    if "P_1ac" in ds:
-        if "bindist" in ds:
-            if ds.attrs["orientation"].upper() == "DOWN":
-                presvar = np.nanmean(ds["P_1ac"]) + ds["bindist"].values
-            elif ds.attrs["orientation"].upper() == "UP":
-                presvar = np.nanmean(ds["P_1ac"]) - ds["bindist"].values
-        else:
-            presvar = np.nanmean(ds["P_1ac"])
-    elif "P_1" in ds:
-        if "bindist" in ds:
-            if ds.attrs["orientation"].upper() == "DOWN":
-                presvar = np.nanmean(ds["P_1"]) + ds["bindist"].values
-            elif ds.attrs["orientation"].upper() == "UP":
-                presvar = np.nanmean(ds["P_1"]) - ds["bindist"].values
-        else:
-            presvar = np.nanmean(ds["P_1"])
+    # use global attributes WATER_DEPTH and initial_instrument_height to find depth dim
+    if "bindist" in ds:
+        if ds.attrs["orientation"].upper() == "DOWN":
+            depvar = (
+                ds.attrs["WATER_DEPTH"]
+                - ds.attrs["initial_instrument_height"]
+                + ds["bindist"].values
+            )
+        elif ds.attrs["orientation"].upper() == "UP":
+            depvar = (
+                ds.attrs["WATER_DEPTH"]
+                - ds.attrs["initial_instrument_height"]
+                - ds["bindist"].values
+            )
     else:
-        if "bindist" in ds:
-            if ds.attrs["orientation"].upper() == "DOWN":
-                presvar = ds.attrs["WATER_DEPTH"] + ds["bindist"].values
-            elif ds.attrs["orientation"].upper() == "UP":
-                presvar = ds.attrs["WATER_DEPTH"] - ds["bindist"].values
-        else:
-            presvar = ds.attrs["WATER_DEPTH"] - ds.attrs["initial_instrument_height"]
+        depvar = ds.attrs["WATER_DEPTH"] - ds.attrs["initial_instrument_height"]
 
     if "bindist" in ds:
-        ds["depth"] = xr.DataArray(presvar, dims="depth")
+        ds["depth"] = xr.DataArray(depvar, dims="depth")
     else:
-        ds["depth"] = xr.DataArray([presvar], dims="depth")
+        ds["depth"] = xr.DataArray([depvar], dims="depth")
 
     ds["depth"].attrs["positive"] = "down"
     ds["depth"].attrs["units"] = "m"

--- a/stglib/tests/data/glob_att1123A_msl.txt
+++ b/stglib/tests/data/glob_att1123A_msl.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cc41ffbb0c515d0b834af92f974bf65db4f71dc3b904398208f637b5b4b7748a
-size 1147
+oid sha256:047ab27c375716aa26a1d0440b0dfd41cc2fdc2c1b0fec20335df9ecf3d60ab6
+size 1195

--- a/stglib/tests/data/glob_att1123A_msl.txt
+++ b/stglib/tests/data/glob_att1123A_msl.txt
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:047ab27c375716aa26a1d0440b0dfd41cc2fdc2c1b0fec20335df9ecf3d60ab6
-size 1195
+oid sha256:1bd7c283287942ddf5bd8cda920b6947ff68e4054b4bd5b161be1989e329914e
+size 1199


### PR DESCRIPTION
Update needed because P_1 variable can and often does include pressure due to things other than sea water (e.g atmosheric pressure). Best practice would be to use the WATER_DEPTH and initial_instrument_height attributes to determine the depth dimension because it is expected that WATER_DEPTH attribute was determined relative to a water level datum (e.g. Mean Sea Level, Local Mean Sea Level, or ground water table).