### PR TITLE
Update vec.rst documentation

### DIFF
--- a/doc/vec.rst
+++ b/doc/vec.rst
@@ -11,7 +11,7 @@ First, export data from the Vector software to text format.
 Convert from text to a raw netCDF file with ``.cdf`` extension using runvechdr2cdf.py. This script
 depends on two arguments, the global attribute file and extra configuration information :doc:`configuration files </config>`.
 
-runvechdr2cdf.py
+runvecdat2cdf.py
 ----------------
 
 .. argparse::


### PR DESCRIPTION
the run file for vector to cdf was listed as "runvechdr2cdf.py".  I don't think that run file exists; instead it should be "runvecdat2cdf.py"  I changed the documentation.