### PR TITLE
Fix boundary elevation calculation

### DIFF
--- a/stglib/eofe.py
+++ b/stglib/eofe.py
@@ -639,7 +639,7 @@ def calc_boundary_elev(ds):
             ds["boundary_elevation"] = xr.DataArray(
                 ds.attrs["WATER_DEPTH"]
                 + (ds.brange * -1)
-                + ds.attrs["initial_instrument_height"]
+                - ds.attrs["initial_instrument_height"]
             )
 
     if "height_above_geopotential_datum" in ds.attrs or "NAVD88_ref" in ds.attrs:


### PR DESCRIPTION
Correct sign error in applying initial_instrument_height attribute to the boundary_elevation calculation for Local Mean Sea-Level (LMSL) datum with UP instrument orientation case.