### PR TITLE
Fix selection of values that pass the K_p criterion

### DIFF
--- a/stglib/core/waves.py
+++ b/stglib/core/waves.py
@@ -181,8 +181,9 @@ def define_cutoff(f, Pxx, Kp, noise=0.9):
 
     fpeakcut = 1.1 * f[np.argmax(Pxx)]
     fpeakcutind = np.searchsorted(f, fpeakcut)  # cutoff based on 1.1*fp
-    Kpcutind = np.argmax(Kp <= 0.1)  # cutoff based on Kp<=0.1
+    Kpcutind = np.nonzero(Kp > 0.1)[0][-1]  # cutoff keeping only Kp > 0.1
 
+    # take the more conservative of either K_p or noise cutoff
     if (noisecutind > fpeakcutind) and (noisecutind <= Kpcutind):
         tailind = noisecutind
     elif (noisecutind > fpeakcutind) and (noisecutind > Kpcutind):

--- a/stglib/core/waves.py
+++ b/stglib/core/waves.py
@@ -181,7 +181,10 @@ def define_cutoff(f, Pxx, Kp, noise=0.9):
 
     fpeakcut = 1.1 * f[np.argmax(Pxx)]
     fpeakcutind = np.searchsorted(f, fpeakcut)  # cutoff based on 1.1*fp
-    Kpcutind = np.nonzero(Kp > 0.1)[0][-1] + 1  # cutoff keeping only Kp > 0.1
+    try:
+        Kpcutind = np.nonzero(Kp > 0.1)[0][-1] + 1  # cutoff keeping only Kp > 0.1
+    except IndexError:
+        Kpcutind = 0
 
     # take the more conservative of either K_p or noise cutoff
     if (noisecutind > fpeakcutind) and (noisecutind <= Kpcutind):

--- a/stglib/core/waves.py
+++ b/stglib/core/waves.py
@@ -181,7 +181,7 @@ def define_cutoff(f, Pxx, Kp, noise=0.9):
 
     fpeakcut = 1.1 * f[np.argmax(Pxx)]
     fpeakcutind = np.searchsorted(f, fpeakcut)  # cutoff based on 1.1*fp
-    Kpcutind = np.nonzero(Kp > 0.1)[0][-1]  # cutoff keeping only Kp > 0.1
+    Kpcutind = np.nonzero(Kp > 0.1)[0][-1] + 1  # cutoff keeping only Kp > 0.1
 
     # take the more conservative of either K_p or noise cutoff
     if (noisecutind > fpeakcutind) and (noisecutind <= Kpcutind):


### PR DESCRIPTION
The old way would not properly handle a situation where K_p values were all greater than 0.1. For example, if `Kp = np.array([1, .5, .11])`, then the old way of computing the index, `Kpcutind = np.argmax(Kp <= 0.1)` will return `0`. In this case we want to have the "cutoff" be the entire array, not none of the array. To fix this, we change to `np.nonzero(Kp > 0.1)[0][-1] + 1` which is the index of the last value in the array, plus 1.

If `Kp = np.array([1, .5, .11, .1, .09, .01])`, then the old and new approach both yield `3`.