### PR TITLE
Vector_thresholds

### DIFF
--- a/stglib/vec/cdf2nc.py
+++ b/stglib/vec/cdf2nc.py
@@ -447,9 +447,7 @@ def fill_snr(ds):
                 )
                 ds = utils.insert_note(ds, v, histtext)
 
-            ds = utils.insert_history(ds, histtext)
-    else:
-        print("Did not fill velocity data using snr threshold")
+        ds = utils.insert_history(ds, histtext)
 
     return ds
 
@@ -476,8 +474,6 @@ def fill_cor(ds):
                 ds = utils.insert_note(ds, v, histtext)
 
             ds = utils.insert_history(ds, histtext)
-    else:
-        print("Did not fill velocity data using cor threshold")
 
     return ds
 

--- a/stglib/vec/cdf2nc.py
+++ b/stglib/vec/cdf2nc.py
@@ -61,6 +61,7 @@ def cdf_to_nc(cdf_filename, atmpres=False):
         ds[var].encoding["coordinates"] = None
         ds = qaqc.trim_min(ds, var)
         ds = qaqc.trim_max(ds, var)
+        ds = qaqc.trim_maxabs_diff(ds, var)
         ds = qaqc.trim_min_diff(ds, var)
         ds = qaqc.trim_min_diff_pct(ds, var)
         ds = qaqc.trim_max_diff(ds, var)
@@ -73,7 +74,6 @@ def cdf_to_nc(cdf_filename, atmpres=False):
         ds = qaqc.trim_bad_ens_indiv(ds, var)
         ds = qaqc.trim_fliers(ds, var)
         ds = qaqc.trim_warmup(ds, var)
-        ds = qaqc.trim_maxabs_diff(ds, var)
 
     # after check for masking vars by other vars
     for var in ds.data_vars:


### PR DESCRIPTION
Added SNR and COR thresholds to fill velocity data. Other minor changes included in this feature branch are: 
- added the ability to use trim_maxabs_diff for burst shaped data
- Changed dtype float64 to float32 to save space and drop file writing time
- removed z dims from variables to save space and drop file writing time (z coordinates still remain)